### PR TITLE
In-progress Jenkins build results are considered failed

### DIFF
--- a/jobs/build_health.rb
+++ b/jobs/build_health.rb
@@ -116,7 +116,7 @@ def get_jenkins_build_health(build_id)
   latest_build = builds[0]
   return {
     name: latest_build['fullDisplayName'],
-    status: latest_build['result'] == 'SUCCESS' ? SUCCESS : FAILED,
+    status: latest_build['result'] == 'SUCCESS' || latest_build['result'].nil? ? SUCCESS : FAILED,
     duration: latest_build['duration'] / 1000,
     link: latest_build['url'],
     health: calculate_health(successful_count, builds.count),


### PR DESCRIPTION
When a Jenkins build is in-progress, its result is null. If Dashing polls for the result while the build is running, it will be reflected as a failure on the dashboard (particularly noticeable in projects with long build times).

A dashboard's purpose is to provide at-a-glance information. Incorrectness in a context where the information drives reactive behavior may result in wasteful activities and, over time, something akin to alert fatigue.

This commit changes the interpretation of a "null" build result in Jenkins from failure to success. Some questionable assumptions are made:

1. A Jenkins build result of "null" means the build is in-progress.
2. An in-progress build should still be displayed in Dashing.
3. In-progress builds should be considered successful until proven otherwise.

I look at this as a workaround rather than a proper fix. For all I know, this problem may affect other build providers, and any of these assumptions could be refuted. I got past the problem within my specific context and am sharing that effort. If there is a desire for assistance with a more comprehensive effort, let me know.