### PR TITLE
Modifying the gemlock file and enabling building status on jenkins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'dashing'
 gem 'dotenv'
 gem 'teamcity-ruby-client'
+gem 'coffee-script-source', '= 1.8.0'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     coffee-script (2.2.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.10.0)
+    coffee-script-source (1.8.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,9 +94,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  coffee-script-source (= 1.8.0)
   dashing
   dotenv
   rspec
   rspec-mocks
   teamcity-ruby-client
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/jobs/build_health.rb
+++ b/jobs/build_health.rb
@@ -110,7 +110,6 @@ def get_bamboo_build_health(build_id)
 end
 
 def get_jenkins_build_status(current_build, latest_build)
-  status = FAILED
   if current_build['building'] then
     return BUILDING
   else

--- a/jobs/build_health.rb
+++ b/jobs/build_health.rb
@@ -1,5 +1,6 @@
 SUCCESS = 'Successful'
 FAILED = 'Failed'
+BUILDING = 'Building'
 
 def api_functions
   return {
@@ -108,16 +109,29 @@ def get_bamboo_build_health(build_id)
   }
 end
 
+def get_jenkins_build_status(current_build, latest_build)
+  status = FAILED
+  if current_build['building'] then
+    return BUILDING
+  else
+    return latest_build['result'] == 'SUCCESS' ? SUCCESS : FAILED
+  end
+end
+
 def get_jenkins_build_health(build_id)
-  url = "#{Builds::BUILD_CONFIG['jenkinsBaseUrl']}/job/#{build_id}/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]"
+  url = "#{Builds::BUILD_CONFIG['jenkinsBaseUrl']}/job/#{build_id}/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]"
   build_info = get_url URI.encode(url)
   builds = build_info['builds']
   builds_with_status = builds.select { |build| !build['result'].nil? }
   successful_count = builds_with_status.count { |build| build['result'] == 'SUCCESS' }
   latest_build = builds_with_status.first
+  current_build = builds.first
+
+  status = get_jenkins_build_status(current_build, latest_build)
+
   return {
     name: latest_build['fullDisplayName'],
-    status: latest_build['result'] == 'SUCCESS' ? SUCCESS : FAILED,
+    status: status,
     duration: latest_build['duration'] / 1000,
     link: latest_build['url'],
     health: calculate_health(successful_count, builds_with_status.count),

--- a/spec/jenkins_spec.rb
+++ b/spec/jenkins_spec.rb
@@ -6,6 +6,7 @@ describe 'get build data from jenkins' do
   before(:each) do
     @jenkins_response = {
       "builds" => [{
+        "building" => false,
         "duration" => 10000,
         "fullDisplayName" => "a build",
         "id" => "15",
@@ -14,13 +15,13 @@ describe 'get build data from jenkins' do
         "url" => "urlOfSorts"
       }]
     }
-    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]').
+    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]').
          to_return(:status => 200, :body => @jenkins_response.to_json, :headers => {})
   end
 
   it 'should get jenkins build info from jenkins api' do
     build_health = get_build_health 'id' => 'jenkins-build', 'server' => 'Jenkins'
-    expect(WebMock.a_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]')).to have_been_made
+    expect(WebMock.a_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]')).to have_been_made
   end
 
   it 'should return the name of the build' do
@@ -36,6 +37,7 @@ describe 'get build data from jenkins' do
   it 'should return the status of the latest build when Failed' do
     failed_build = {
       "builds" => [{
+        "building" => false,
         "duration" => 427875,
         "fullDisplayName" => "a build",
         "id" => "1",
@@ -44,7 +46,7 @@ describe 'get build data from jenkins' do
         "url" => "someurl/1/"
       }]
     }
-    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]').
+    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]').
          to_return(:status => 200, :body => failed_build.to_json, :headers => {})
     build_health = get_build_health 'id' => 'jenkins-build', 'server' => 'Jenkins'
     expect(build_health[:status]).to eq('Failed')
@@ -68,6 +70,7 @@ describe 'get build data from jenkins' do
   it 'should return the build health' do
     so_so = {
       "builds" => [{
+        "building" => false,
         "duration" => 459766,
         "fullDisplayName" => "a build",
         "id" => "15",
@@ -75,6 +78,7 @@ describe 'get build data from jenkins' do
         "timestamp" => 1453489268807,
         "url" => "someurl/15/"
       }, {
+        "building" => false,
         "duration" => 427875,
         "fullDisplayName" => "a build",
         "id" => "1",
@@ -83,7 +87,7 @@ describe 'get build data from jenkins' do
         "url" => "someurl/1/"
       }]
     }
-    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]').
+    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]').
          to_return(:status => 200, :body => so_so.to_json, :headers => {})
     build_health = get_build_health 'id' => 'jenkins-build', 'server' => 'Jenkins'
     expect(build_health[:health]).to eq(50)
@@ -92,6 +96,7 @@ describe 'get build data from jenkins' do
   it 'should return the build status of the latest non-nil build' do
     running_builds = {
       "builds" => [{
+        "building" => false,
         "duration" => 459766,
         "fullDisplayName" => "a build",
         "id" => "15",
@@ -99,6 +104,7 @@ describe 'get build data from jenkins' do
         "timestamp" => 1453489268807,
         "url" => "someurl/15/"
       }, {
+        "building" => false,
         "duration" => 427875,
         "fullDisplayName" => "a build",
         "id" => "1",
@@ -107,6 +113,7 @@ describe 'get build data from jenkins' do
         "url" => "someurl/1/"
       },
       {
+        "building" => false,
         "duration" => 427875,
         "fullDisplayName" => "a build",
         "id" => "1",
@@ -115,7 +122,7 @@ describe 'get build data from jenkins' do
         "url" => "someurl/1/"
       }]
     }
-    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]').
+    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]').
          to_return(:status => 200, :body => running_builds.to_json, :headers => {})
     build_health = get_build_health 'id' => 'jenkins-build', 'server' => 'Jenkins'
     expect(build_health[:status]).to eq('Successful')
@@ -124,6 +131,7 @@ describe 'get build data from jenkins' do
   it 'should not include running builds in the build health calculation' do
     running_builds = {
       "builds" => [{
+        "building" => false,
         "duration" => 459766,
         "fullDisplayName" => "a build",
         "id" => "15",
@@ -131,6 +139,7 @@ describe 'get build data from jenkins' do
         "timestamp" => 1453489268807,
         "url" => "someurl/15/"
       }, {
+        "building" => false,
         "duration" => 427875,
         "fullDisplayName" => "a build",
         "id" => "1",
@@ -139,6 +148,7 @@ describe 'get build data from jenkins' do
         "url" => "someurl/1/"
       },
       {
+        "building" => false,
         "duration" => 427875,
         "fullDisplayName" => "a build",
         "id" => "1",
@@ -147,10 +157,44 @@ describe 'get build data from jenkins' do
         "url" => "someurl/1/"
       }]
     }
-    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,timestamp,id,result,duration,url,fullDisplayName]').
+    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]').
          to_return(:status => 200, :body => running_builds.to_json, :headers => {})
     build_health = get_build_health 'id' => 'jenkins-build', 'server' => 'Jenkins'
     expect(build_health[:health]).to eq(100)
+  end
+
+  it 'should return status of the build as building when the current build is in a building state' do
+    running_build = {
+      "builds" => [{
+        "building" => true,
+        "duration" => 459766,
+        "fullDisplayName" => "a build",
+        "id" => "15",
+        "result" => "",
+        "timestamp" => 1453489268807,
+        "url" => "someurl/15/"
+      }, {
+        "building" => false,
+        "duration" => 427875,
+        "fullDisplayName" => "second build",
+        "id" => "1",
+        "result" => "FAILURE",
+        "timestamp" => 1451584715235,
+        "url" => "someurl/1/"
+      }, {
+        "building" => false,
+        "duration" => 427875,
+        "fullDisplayName" => "another build",
+        "id" => "2",
+        "result" => "SUCCESS",
+        "timestamp" => 1451584715235,
+        "url" => "someurl/1/"
+      }]
+    }
+    stub_request(:get, 'http://jenkins-url/job/jenkins-build/api/json?tree=builds[status,building,timestamp,id,result,duration,url,fullDisplayName]').
+         to_return(:status => 200, :body => running_build.to_json, :headers => {})
+    build_health = get_build_health 'id' => 'jenkins-build', 'server' => 'Jenkins'
+    expect(build_health[:status]).to eq('Building')
   end
 
 end

--- a/widgets/build_window/build_window.coffee
+++ b/widgets/build_window/build_window.coffee
@@ -6,15 +6,11 @@ Batman.Filters.durationFormat = (duration) ->
 
 class Dashing.BuildWindow extends Dashing.Widget
   onData: (data) ->
-    switch data.status
-      when 'Failed'
-        $(@node).css('background-color', '#a73737')
-      when 'Successful'
-        $(@node).css('background-color', '#03A06E')
-      when 'Building'
-        $(@node).css('background-color', '#999900')
-      else
-        $(@node).css('background-color', '#808080')
+    status = data.status
+    if (status == 'Failed') then $(@node).css('background-color', '#a73737')
+    else if (status == 'Successful') then $(@node).css('background-color', '#03A06E')
+    else if (status == 'Building') then $(@node).css('background-color', '#999900')
+    else $(@node).css('background-color', '#808080')
 
   @accessor 'image', ->
     health = @get('health')

--- a/widgets/build_window/build_window.coffee
+++ b/widgets/build_window/build_window.coffee
@@ -6,10 +6,15 @@ Batman.Filters.durationFormat = (duration) ->
 
 class Dashing.BuildWindow extends Dashing.Widget
   onData: (data) ->
-    if data.status == 'Failed'
-      $(@node).css('background-color', '#a73737')
-    else if data.status == 'Successful'
-      $(@node).css('background-color', '#03A06E')
+    switch data.status
+      when 'Failed'
+        $(@node).css('background-color', '#a73737')
+      when 'Successful'
+        $(@node).css('background-color', '#03A06E')
+      when 'Building'
+        $(@node).css('background-color', '#999900')
+      else
+        $(@node).css('background-color', '#808080')
 
   @accessor 'image', ->
     health = @get('health')


### PR DESCRIPTION
I have added the possibility to display a yellow dashboard while the build is running for jenkins so that there is some visual feedback for the user. Also modified the gemfile as the latest version of coffee-script-source 1.10.0 or 1.9.0 does not work on windows systems so have dropped the version to 1.8.0.