### PR TITLE
Initial Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.1.8-alpine
+
+RUN apk update && \
+    apk upgrade && \
+    apk add bash curl-dev ruby-dev build-base nodejs && \
+    rm -rf /var/cache/apk/*
+
+COPY . /build-window
+
+WORKDIR /build-window
+
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Run `dashing start -d -p 3031` to run it as a daemon and to specify the port. Yo
 
 See https://github.com/Shopify/dashing/wiki for more details.
 
+## Docker support
+
+You can spin up a Docker container with build-window by running:
+
+`docker-compose up -d`
+
+The application will be ready at `http://localhost:3030` (Linux) or at `http://<DOCKER_HOST_IP>:3030` (Windows/OS X).
+
+**PS:** You can also build the image and run a container separately, but [Docker Compose](https://docs.docker.com/compose/install/) makes this process much simpler.
+
 ## Contributing
 
 Pull requests welcome. Run the tests with `rspec`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+build-window:
+  build: .
+  ports:
+    - "3030:3030"
+    - "3031:3031"
+  command: dashing start


### PR DESCRIPTION
Hi,

This PR includes Docker support for build-window. I created a Dockerfile from an official Ruby 2.1.8 minimal base image (which uses Alpine Linux). I'm aware that the project was built in Ruby 2.1.3, but unfortunately the official Ruby repository only provides 2.1.8 images (https://hub.docker.com/_/ruby/).

To make things more simple, I included a Docker Compose file, which builds an image using the mentioned Dockefile, maps host/container ports (3030 and 3031) and runs `dashing start`.

I'm currently using this at my company and it's working nicely. We are still looking for the best way to manage dashboard changes using volumes, so I plan to create a new PR in a few weeks to improve that. Either way, I thought that an initial Docker support would be helpful for new users :)

Thanks!
Stefan