### PR TITLE
Work around ruby update error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM ruby:2.1.8-alpine
 RUN apk update && \
     apk upgrade && \
     apk add bash curl-dev ruby-dev build-base nodejs && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    gem update --system 2.6.1 && \
+    gem update bundler
 
 COPY . /build-window
 


### PR DESCRIPTION
Apparently due to some breakage in the ruby / gem toolchain, ```docker-compose up``` fails with the following error:

```
build-window_1  | /usr/local/bin/bundle:22:in `load': cannot load such file -- /usr/local/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/
gems/bundler-1.11.2/bin/bundle (LoadError)
build-window_1  |       from /usr/local/bin/bundle:22:in `<main>'
buildwindow_build-window_1 exited with code 0
```

Fixing rubygems to version 2.6.1 seems to work around the problem.