### PR TITLE
Upgrade ruby version and timezone info 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1.8-alpine
+FROM ruby:2.6-alpine
 
 RUN apk update && \
     apk upgrade && \

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'tzinfo-data'
 gem 'smashing'
 gem 'dotenv'
 gem 'teamcity-ruby-client'


### PR DESCRIPTION
Dockerfile was referring to an older version of Ruby. Bundler version was not compatible with it. Upgraded.
When running the docker file an error regarding Timezone info appeared. The solution was to add the tzinfo-data gem installed as well. 